### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /backend
 
 COPY src ./src
 COPY types ./types
-COPY utils ./utils
 COPY index.ts ./index.ts
 COPY package.json ./package.json
 COPY yarn.lock ./yarn.lock
@@ -26,4 +25,4 @@ RUN yarn
 RUN npx tsc
 
 EXPOSE 3000
-CMD ["npx", "typeorm", "migration:run", "&&", "npm", "run", "serve", "--", "-o", "0.0.0.0"]
+CMD ["sh", "-c", "npx typeorm migration:run && npm run serve -- -o 0.0.0.0"]


### PR DESCRIPTION
This commit:
- should fix the build on master
- removes copying "utils" as they were probably earlier moved to "src"
- fixes the CMD that broke the build, previous version didn't work because "&&" was being passed as a parameter to "npx typeorm migration:run" command. I found more info on CMD syntaxes here: https://docs.docker.com/engine/reference/builder/#cmd

It can also be merged to master.